### PR TITLE
Adds guardrails around potential empty strings for hover doc

### DIFF
--- a/lua/pretty_hover/util.lua
+++ b/lua/pretty_hover/util.lua
@@ -142,6 +142,10 @@ M.close_float = function()
 end
 
 M.open_float = function(hover_text, config)
+	if not hover_text or hover_text:len() == 0 then
+		-- There is nothing to display, quit out early
+		return
+	end
 	-- Convert Doxygen comments to Markdown format
 	local tbl = M.convert_to_markdown(hover_text, config)
 	if #tbl == 0 then

--- a/lua/pretty_hover/util.lua
+++ b/lua/pretty_hover/util.lua
@@ -144,6 +144,7 @@ end
 M.open_float = function(hover_text, config)
 	if not hover_text or hover_text:len() == 0 then
 		-- There is nothing to display, quit out early
+		vim.notify("No information available", vim.log.levels.INFO)
 		return
 	end
 	-- Convert Doxygen comments to Markdown format


### PR DESCRIPTION
Addresses potential issue where `require("pretty_hover").hover()` is called on something that produces an empty string for its hover doc contents.

To demonstrate this issue, you can paste the following code into a buffer, set its filetype to `lua` and connect `lua_ls` to it.

```lua
-- Move cursor to end of the below number, then call `require("pretty_hover").hover()`
local num = 1000
```

This will populate the following error
```
Error executing vim.schedule lua callback: ...vim/neovim-0.9.0/share/nvim/runtime/lua/vim/lsp/util.lua:1682: 'width' key must be a positive Integer
stack traceback:
        [C]: in function 'nvim_open_win'
        ...vim/neovim-0.9.0/share/nvim/runtime/lua/vim/lsp/util.lua:1682: in function 'open_floating_preview'
        ...lazy/pretty_hover/lua/pretty_hover/util.lua:156: in function 'open_float'
        ...lazy/pretty_hover/lua/pretty_hover/init.lua:34: in function 'callback'
        /opt/neovim/neovim-0.9.0/share/nvim/runtime/lua/vim/lsp.lua:2021: in function 'handler'
        /opt/neovim/neovim-0.9.0/share/nvim/runtime/lua/vim/lsp.lua:1394: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

This ensures that anything that might generate an `empty` string for its lsp doc will not be passed into the utility to create the hover window (and thus mitigate the above error).