### PR TITLE
Typescript-tools.nvim workaround (#14)

### DIFF
--- a/lua/pretty_hover/init.lua
+++ b/lua/pretty_hover/init.lua
@@ -21,6 +21,19 @@ local function local_hover_request(responses)
 				end
 			else
 				local hover_text = response.result.contents.value
+				-- typescript-tools.nvim workaround
+				if hover_text == nil then
+					hover_text = response.result.contents[1].value
+					for i = 2, #response.result.contents do
+						if type(response.result.contents[i]) ~= "string" then
+							vim.notify("Unexpected item type found in hover request's response.\n" ..
+								"Please report an issue on github: https://github.com/Fildo7525/pretty_hover",
+								vim.log.levels.ERROR)
+							break
+						end
+						hover_text = hover_text .. response.result.contents[i]
+					end
+				end
 				h_util.open_float(hover_text, M.config)
 			end
 		end


### PR DESCRIPTION
I managed to find a fix for #14.

Example of hover [responses](https://github.com/Fildo7525/pretty_hover/blob/a8409e4bdf6a6b8768b855ff29fe6e4c3315bc54/lua/pretty_hover/init.lua#L9) from tsserver:
```lua 
{
  [2] = {
    result = {
      contents = { {
          kind = "markdown",
          value = "```typescript\nconst React.StrictMode: React.ExoticComponent<{\n    children?: React.ReactNode;\n}>\n```\n"
        }, "Lets you find common bugs in your components early during development.", "\n_@see_ — {@link https://react.dev/reference/react/StrictMode React Docs}\n\n_@example_ — ```tsx\nimport { StrictMode } from 'react';\n\n<StrictMode>\n  <App />\n</StrictMode>\n
" },
      range = {
        ["end"] = {
          character = 20,
          line = 8
        },
        start = {
          character = 10,
          line = 8
        }
      }
    }
  },
  [3] = {}
}
```