### PR TITLE
Removing highlight from selection after window closes

### DIFF
--- a/lua/pretty_hover/core/util.lua
+++ b/lua/pretty_hover/core/util.lua
@@ -136,7 +136,7 @@ end
 
 --- This function checks all the active clients for current buffer and returns the active client that supports the current file type.
 ---@return table|nil Active client for the current buffer or nil if there is no active client.
-function M.get_current_active_clent()
+function M.get_current_active_client()
 	for _, client in ipairs(compatibility.get_clients()) do
 		if M.tbl_contains(client.config.filetypes, vim.bo.filetype) then
 			return client
@@ -220,6 +220,8 @@ function M.open_float(hover_text, format, config)
 		silent = true,
 		nowait = true,
 	})
+
+    return bufnr, winnr
 end
 
 return M

--- a/lua/pretty_hover/init.lua
+++ b/lua/pretty_hover/init.lua
@@ -125,7 +125,17 @@ local function local_hover_request(results, ctx)
 		return
 	end
 
-	h_util.open_float(contents, format, M.config)
+	local _, winnr = h_util.open_float(contents, format, M.config)
+    
+    -- Remove selection highlighting after window is closed
+    api.nvim_create_autocmd('WinClosed', {
+        pattern = tostring(winnr),
+        once = true,
+        callback = function()
+            api.nvim_buf_clear_namespace(bufnr, hover_ns, 0, -1)
+            return true
+        end,
+    })
 end
 
 --- Parses the response from the server and displays the hover information converted to markdown.
@@ -134,7 +144,7 @@ function M.hover(config)
 	local params = util.make_position_params(0, 'utf-16')
 
 	-- Check if the server for this file type exists and supports hover.
-	local client = h_util.get_current_active_clent()
+	local client = h_util.get_current_active_client()
 	local hover_support_present = client and client.capabilities.textDocument.hover
 
 	if not client or not hover_support_present then


### PR DESCRIPTION
This PR addresses an issue I recently encountered using this plugin where after calling `require('pretty_hover').hover()`, the highlighting that is applied to the selected text is never removed, even after closing the window. To fix this, I simply added a snippet of code found in the lsp module of the Neovim runtime which creates an auto-command which removes the highlighting after the window is closed. 

While I was at it, I saw that the function `get_current_active_client()` in the core.util module was misspelled as `get_current_active_clent()`, so I updated that as well.