### PR TITLE
fix: hover_text nil

### DIFF
--- a/lua/pretty_hover/local_request.lua
+++ b/lua/pretty_hover/local_request.lua
@@ -25,7 +25,7 @@ local function parse_response_contents(contents)
 	if not pcall(function() hover_text = contents[1].value end) then
 		return
 	end
-
+	hover_text = ""
 	for i = 2, #contents do
 		if type(contents[i]) ~= "string" then
 			vim.notify("Unexpected item type found in hover request's response.\n" ..

--- a/lua/pretty_hover/local_request.lua
+++ b/lua/pretty_hover/local_request.lua
@@ -25,7 +25,7 @@ local function parse_response_contents(contents)
 	if not pcall(function() hover_text = contents[1].value end) then
 		return
 	end
-	hover_text = ""
+	hover_text = hover_text or ""
 	for i = 2, #contents do
 		if type(contents[i]) ~= "string" then
 			vim.notify("Unexpected item type found in hover request's response.\n" ..


### PR DESCRIPTION
when using `msbuild_project_tools_server` lsp, `contents` = `{ "Property: `Nullable`", "Value: `enable`" }` => hover_text is `nil`. And we concat `nil` with string, which throws this error message:
```
vim.schedule callback: ...vim/lazy/pretty_hover/lua/pretty_hover/local_request.lua:36: attempt to concatenate local 'hover_text' (a nil value)
stack traceback:
	...vim/lazy/pretty_hover/lua/pretty_hover/local_request.lua:36: in function 'parse_response_contents'
	...vim/lazy/pretty_hover/lua/pretty_hover/local_request.lua:63: in function 'request_below11'
	...vim/lazy/pretty_hover/lua/pretty_hover/local_request.lua:199: in function 'handler'
	...stalls/neovim/nightly/share/nvim/runtime/lua/vim/lsp.lua:1333: in function 'handler'
	...neovim/nightly/share/nvim/runtime/lua/vim/lsp/client.lua:732: in function ''
	vim/_core/editor.lua: in function <vim/_core/editor.lua:0>
```